### PR TITLE
feat: do not create LokiRule by default

### DIFF
--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -165,7 +165,7 @@ app:
 | `alerting.logs.levels.*.severity`               | `warning`                   | The severity of the alert when the maximum count of a messages of a specific log level is exceeded       |
 | `alerting.logs.levels.lokiConfigMap.label`      | `loki_rule`                 | The label attached to the ConfigMap holding the Loki Rules                                               |
 | `alerting.logs.levels.lokiConfigMap.labelValue` | `""`                        | The value of the label attached to the Loki Rule ConfigMap                                               |
-| `alerting.logs.levels.createLokiRule`           | `true`                      | Whether to create a LokiRule CR or not (useful when transitioning from loki-rule-operator)               |
+| `alerting.logs.levels.createLokiRule`           | `false`                     | Whether to create a LokiRule CR or not (useful when transitioning from loki-rule-operator)               |
 | `alerting.custom.*.metric`                      | __required if used__        | The name of the Prometheus metric exposed by the service                                                 |
 | `alerting.custom.*.labelMatchers`               |                             | Prometheus label matchers to use for filtering the metric (e.g., `some_key="some_value"`)                |
 | `alerting.custom.*.aggregate`                   | __required if used__        | The aggregate function to use to combine metric values from multiple replicas (e.g., `max` or `sum`)     |

--- a/charts/generic-service/ci/log-alerts-both-values.yaml
+++ b/charts/generic-service/ci/log-alerts-both-values.yaml
@@ -12,6 +12,7 @@ alerting:
         severity: Warning
         maxCount: 10
       error: {}
+    createLokiRule: true
     lokiConfigMap:
       label: "loki_rule"
       labelValue: ""

--- a/charts/generic-service/ci/log-alerts-operator-values.yaml
+++ b/charts/generic-service/ci/log-alerts-operator-values.yaml
@@ -14,3 +14,4 @@ alerting:
       error: {}
     # setting this to an empty object (`{}`) will not suppress cm creation, use `null` instead
     lokiConfigMap: null
+    createLokiRule: true

--- a/charts/generic-service/ci/log-alerts-sidecar-values.yaml
+++ b/charts/generic-service/ci/log-alerts-sidecar-values.yaml
@@ -15,4 +15,3 @@ alerting:
     lokiConfigMap:
       label: "loki_rule"
       labelValue: ""
-    createLokiRule: false

--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -956,7 +956,7 @@
             },
             "createLokiRule": {
               "type": "boolean",
-              "default": true,
+              "default": false,
               "description": "Whether to create a LokiRule CR for log alerting or not."
             }
           },

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -179,7 +179,7 @@ alerting:
     countInterval: 5m
     levelLabel: level
     levels: {}
-    createLokiRule: true
+    createLokiRule: false
     lokiConfigMap:
       label: "loki_rule"
       labelValue: ""


### PR DESCRIPTION
Loki Rule Operator is deprecated and Loki rules should rather be managed via the Loki sidecar.