### PR TITLE
Relax schema restrictions on "env"

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: runs a service (with monitoring, ingress, etc.)
 home: https://github.com/nano-byte/helm-charts/tree/master/charts/generic-service
 name: generic-service
-version: 1.10.2
+version: 1.10.3

--- a/charts/generic-service/ci/config-values.yaml
+++ b/charts/generic-service/ci/config-values.yaml
@@ -6,6 +6,7 @@ image:
 
 env:
   SOME_KEY: some-value
+  SOME_NUMERIC_KEY: 1234
 
 config:
   some-key: some-value

--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -83,7 +83,6 @@
     },
     "env": {
       "type": "object",
-      "additionalProperties": {"type": "string"},
       "description": "Environment variables passed to the service as a key-value map"
     },
     "envFrom": {

--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -83,6 +83,7 @@
     },
     "env": {
       "type": "object",
+      "additionalProperties": {"type": ["string", "number", "boolean"]},
       "description": "Environment variables passed to the service as a key-value map"
     },
     "envFrom": {


### PR DESCRIPTION
The container environment variables are already automatically quoted:
https://github.com/nano-byte/helm-charts/blob/45c2591c9594645daba75178e3f0925879803eac/charts/generic-service/templates/controller.yaml#L422

But it was still not possible to use integers because the values schema enforced string properties. Removing this restriction allows to reuse values like this:

```yaml
monitoring:
  enabled: true
  port: &servicePort 1234  # <-- this requires an integer by definition

env:
  SERVICE_PORT: *servicePort  # <-- this previously required a string, but now can also be an integer
```