### PR TITLE
generic service: allow non-integer values for timeoutSeconds

### DIFF
--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -514,7 +514,7 @@
           "description": "The internal protocol used for ingress"
         },
         "timeoutSeconds": {
-          "type": ["integer", "null"],
+          "type": ["number", "null"],
           "description": "Number of seconds after which to timeout waiting for response from service; -1 for infinite"
         },
         "domains": {
@@ -659,7 +659,7 @@
                 "description": "The protocol used for the port"
               },
               "timeoutSeconds": {
-                "type": ["integer", "null"],
+                "type": ["number", "null"],
                 "description": "Number of seconds after which to timeout waiting for response from service; -1 for infinite"
               },
               "domains": {


### PR DESCRIPTION
This will allow setting shorter timeouts for quick operations, like `0.5` 

I checked all the usages, according to documentation, they should be able to handle decimal values