### PR TITLE
Revert "generic service: allow non-integer values for timeoutSeconds"

### DIFF
--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -514,7 +514,7 @@
           "description": "The internal protocol used for ingress"
         },
         "timeoutSeconds": {
-          "type": ["number", "null"],
+          "type": ["integer", "null"],
           "description": "Number of seconds after which to timeout waiting for response from service; -1 for infinite"
         },
         "domains": {
@@ -659,7 +659,7 @@
                 "description": "The protocol used for the port"
               },
               "timeoutSeconds": {
-                "type": ["number", "null"],
+                "type": ["integer", "null"],
                 "description": "Number of seconds after which to timeout waiting for response from service; -1 for infinite"
               },
               "domains": {


### PR DESCRIPTION
Reverts nano-byte/helm-charts#48

I'm very sorry, it appears that while `nginx.ingress.kubernetes.io/proxy-read-timeout` supports the decimal, `nginx.ingress.kubernetes.io/server-snippet: "grpc_read_timeout ..."` does not.