### PR TITLE
Disable TLS by default

### DIFF
--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -138,6 +138,7 @@ app:
 | `tracing.enabled`                               | `false`                     | Enables tracing with OpenTelemetry or Jaeger agent (injected as sidecar)                                 |
 | `tracing.probability`                           | `1`                         | Probability of any single trace being sampled; can be overridden for incoming requests e.g. via Istio    |
 | `tracing.class`                                 |                             | Custom value to set for tracing sidecar injection annotations                                            |
+| `tracing.insecure                               | `true`                      | Use insecure connections (without TLS) to tracing endpoints in local sidecar container                   |  
 | `monitoring.enabled`                            | `false`                     | Use Prometheus for monitoring / metrics scraping                                                         |
 | `monitoring.port`                               | `9100`                      | The port to be scraped for monitoring data                                                               |
 | `monitoring.path`                               | `/metrics`                  | The path to be scraped for monitoring data                                                               |

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -138,7 +138,7 @@ app:
 | `tracing.enabled`                               | `false`                     | Enables tracing with OpenTelemetry or Jaeger agent (injected as sidecar)                                 |
 | `tracing.probability`                           | `1`                         | Probability of any single trace being sampled; can be overridden for incoming requests e.g. via Istio    |
 | `tracing.class`                                 |                             | Custom value to set for tracing sidecar injection annotations                                            |
-| `tracing.insecure                               | `true`                      | Use insecure connections (without TLS) to tracing endpoints in local sidecar container                   |  
+| `tracing.insecure`                              | `true`                      | Use insecure connections (without TLS) to tracing endpoints in local sidecar container                   |  
 | `monitoring.enabled`                            | `false`                     | Use Prometheus for monitoring / metrics scraping                                                         |
 | `monitoring.port`                               | `9100`                      | The port to be scraped for monitoring data                                                               |
 | `monitoring.path`                               | `/metrics`                  | The path to be scraped for monitoring data                                                               |

--- a/charts/generic-service/templates/controller.yaml
+++ b/charts/generic-service/templates/controller.yaml
@@ -401,7 +401,7 @@ spec:
               value: {{ include "generic-service.fullname" . }}
             {{- end }}
             - name: OTEL_EXPORTER_OTLP_INSECURE
-              value: {{ .Values.tracing.insecure }}
+              value: {{ .Values.tracing.insecure | quote }}
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: 'service.namespace={{ .Release.Namespace }},service.version={{ .Values.version | default .Values.image.tag }},service.instance.id=$(POD_NAME),k8s.node.name=$(NODE_NAME)'
             {{- if ne (float64 .Values.tracing.probability) 1.0 }}

--- a/charts/generic-service/templates/controller.yaml
+++ b/charts/generic-service/templates/controller.yaml
@@ -400,6 +400,8 @@ spec:
             - name: JAEGER_SERVICE_NAME
               value: {{ include "generic-service.fullname" . }}
             {{- end }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.tracing.insecure }}
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: 'service.namespace={{ .Release.Namespace }},service.version={{ .Values.version | default .Values.image.tag }},service.instance.id=$(POD_NAME),k8s.node.name=$(NODE_NAME)'
             {{- if ne (float64 .Values.tracing.probability) 1.0 }}

--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -747,6 +747,11 @@
           "type": "string",
           "default": "true",
           "description": "Custom value to set for tracing sidecar injection annotations"
+        },
+        "insecure": {
+          "type": "boolean",
+          "default": true,
+          "description": "By default if tracing is enabled, a sidecar is injected without TLS. Set this to false, if the sidecar serves the tracing endpoints via TLS."
         }
       },
       "additionalProperties": false

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -144,6 +144,8 @@ tracing:
   enabled: false
   probability: 1
   class: ''
+  # By default if tracing is enabled, a sidecar is injected without TLS. 
+  insecure: 'true'
 
 monitoring:
   enabled: false

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -144,8 +144,7 @@ tracing:
   enabled: false
   probability: 1
   class: ''
-  # By default if tracing is enabled, a sidecar is injected without TLS. 
-  insecure: 'true'
+  insecure: true
 
 monitoring:
   enabled: false


### PR DESCRIPTION
OTEL_EXPORTER_OTLP_INSECURE is an environment variable understood by most gRPC trace exporter clients. In most cases, the sidecar injected don't setup a TLS certificate as the connection is local to the pod. A user can however, set this to false again, if they use TLS in their setup for the local tracing sidecar.