### PR TITLE
fix: typo timout -> timeout

### DIFF
--- a/charts/generic-service/templates/alerts.yaml
+++ b/charts/generic-service/templates/alerts.yaml
@@ -188,11 +188,11 @@ spec:
         - alert: HttpTimeout
           expr: |
             sum(round(increase({{ include "generic-service.request-code-count-metric" . }}"504"}[{{ .Values.alerting.http.sampleInterval }}])))
-            > {{ .Values.alerting.http.maxTimoutCount }}
+            > {{ .Values.alerting.http.maxTimeoutCount }}
           labels: {{- include "generic-service.alert-labels" . | nindent 12 }} critical
             topic: ingress
           annotations: {{- include "generic-service.alert-annotations" . | nindent 12 }} HTTP gateway timeout responses
-            description: '{{ include "generic-service.fullname" . }} gave {{"{{ $value }}"}} HTTP gateway timout responses in the last {{ .Values.alerting.http.sampleInterval }}.'
+            description: '{{ include "generic-service.fullname" . }} gave {{"{{ $value }}"}} HTTP gateway timeout responses in the last {{ .Values.alerting.http.sampleInterval }}.'
         {{- end }}
 
         {{- if or (eq .Values.ingress.protocol "grpc") (eq .Values.ingress.protocol "grpcs") }}


### PR DESCRIPTION
This leads to a rendering error when the value is not overridden (with the same typo).