### PR TITLE
feat(sidecars): support native Kubernetes sidecar containers

### DIFF
--- a/charts/generic-service/ci/native-sidecar-values.yaml
+++ b/charts/generic-service/ci/native-sidecar-values.yaml
@@ -1,0 +1,25 @@
+# Native sidecar test
+
+name: test
+fullname: my-test
+
+image:
+  repository: jwilder/whoami
+  tag: latest
+
+launchSidecarFirst: true
+
+sidecars:
+  - name: sidecar1
+    image: jwilder/whoami
+    env:
+      - name: PORT
+        value: '8081'
+
+sidecarTemplates:
+  - |
+      name: sidecar2
+      image: {{ .Values.image.repository }}
+      env:
+        - name: PORT
+          value: '8082'

--- a/charts/generic-service/templates/controller.yaml
+++ b/charts/generic-service/templates/controller.yaml
@@ -474,6 +474,7 @@ spec:
                 command: ["sleep", "{{ .Values.ingress.shutdownDelaySeconds }}"]
           {{- end }}
 
+      {{- if not .Values.launchSidecarFirst }}
       {{- range .Values.sidecars }}
         - securityContext: {{- $.Values.securityContext.container | toYaml | nindent 12 }}
           {{- toYaml . | nindent 10 }}
@@ -485,8 +486,9 @@ spec:
           {{- $spec | nindent 10 }}
       {{- end }}
       {{- end }}
+      {{- end }}
 
-      {{ if or .Values.initContainers .Values.initContainerTemplates }}
+      {{ if or .Values.initContainers .Values.initContainerTemplates (and .Values.launchSidecarFirst (or .Values.sidecars .Values.sidecarTemplates)) }}
       initContainers:
       {{- range .Values.initContainers }}
         - securityContext: {{- $.Values.securityContext.container | toYaml | nindent 12 }}
@@ -497,6 +499,23 @@ spec:
       {{- if $spec }}
         - securityContext: {{- $.Values.securityContext.container | toYaml | nindent 12 }}
           {{- $spec | nindent 10 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.launchSidecarFirst }}
+      {{- range .Values.sidecars }}
+      {{- $sidecar := omit . "restartPolicy" }}
+        - restartPolicy: Always
+          securityContext: {{- $.Values.securityContext.container | toYaml | nindent 12 }}
+          {{- toYaml $sidecar | nindent 10 }}
+      {{- end }}
+      {{- range .Values.sidecarTemplates }}
+      {{- $spec := tpl . $ }}
+      {{- if $spec }}
+      {{- $specMap := omit (fromYaml $spec) "restartPolicy" }}
+        - restartPolicy: Always
+          securityContext: {{- $.Values.securityContext.container | toYaml | nindent 12 }}
+          {{- toYaml $specMap | nindent 10 }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/generic-service/values.schema.json
+++ b/charts/generic-service/values.schema.json
@@ -1443,6 +1443,11 @@
       },
       "description": "Additional sidecar containers to be added to the Pod"
     },
+    "launchSidecarFirst": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to wait for the sidecar's startup probe to succeed before launching the main container."
+    },
     "sidecarsTemplates": {
       "type": "array",
       "items": {

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -206,6 +206,7 @@ initContainerTemplates: []
 
 sidecars: []
 sidecarTemplates: []
+launchSidecarFirst: false
 
 rbac:
   roles: []


### PR DESCRIPTION
## Summary

- Add `launchSidecarFirst` option (default: `false`) that renders `sidecars`/`sidecarTemplates` as init containers with `restartPolicy: Always` (native Kubernetes sidecars) instead of regular containers
- Ensures sidecars start before and outlive the main container (requires Kubernetes 1.29+ or 1.33+ stable)
- Default behavior (`launchSidecarFirst: false`) is unchanged

## Changes

- **`values.yaml`** / **`values.schema.json`**: new `launchSidecarFirst` boolean
- **`controller.yaml`**: conditional rendering of sidecars into `initContainers[]` with `restartPolicy: Always` when enabled
- **`ci/native-sidecar-values.yaml`**: CI lint/template values file

## Test plan

- [x] `helm lint` passes with native sidecar values
- [x] `helm template` output verified: sidecars rendered as init containers with `restartPolicy: Always`